### PR TITLE
Fixed module name in readme example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,7 @@ Here’s a simple Python program:
 
    #!/usr/bin/env python3
    import logging
-   from garmin import garmin, link, logger
+   from pygarmin import garmin, link, logger
 
    logger.log.addHandler(logging.StreamHandler())
    logger.log.setLevel(logging.INFO)


### PR DESCRIPTION
Version 1.2.0 requires to import `pygarmin` instead of `garmin`