### PR TITLE
fix(link): Define error properly

### DIFF
--- a/src/pygarmin/link.py
+++ b/src/pygarmin/link.py
@@ -261,7 +261,7 @@ class SerialLink(P000):
             mod_logger.log.debug("Received NAK packet")
             raise mod_error.LinkError("Packet was not received correctly")
         else:
-            raise GarminError("Received neither ACK nor NAK packet")
+            raise mod_error.GarminError("Received neither ACK nor NAK packet")
 
     def send_ack(self, pid):
         """Send an ACK packet."""


### PR DESCRIPTION
While trying to connect to my Garmin Inreach Mini 2 i got following error:

Traceback (most recent call last):
  File "/home/nuclearcat/.local/bin/pygarmin", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/nuclearcat/.local/lib/python3.12/site-packages/pygarmin/pygarmin.py", line 1509, in main
    command(args)
  File "/home/nuclearcat/.local/lib/python3.12/site-packages/pygarmin/pygarmin.py", line 250, in info
    info += f"Unit ID: {self.gps.unit_id}\n"
                        ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/functools.py", line 995, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/nuclearcat/.local/lib/python3.12/site-packages/pygarmin/garmin.py", line 373, in unit_id
    self.link.send_packet(self.link.pid_command_data,
  File "/home/nuclearcat/.local/lib/python3.12/site-packages/pygarmin/protocol.py", line 27, in send_packet
    self.phys.send_packet(pid, data)
  File "/home/nuclearcat/.local/lib/python3.12/site-packages/pygarmin/link.py", line 235, in send_packet
    self.read_ack(pid)
  File "/home/nuclearcat/.local/lib/python3.12/site-packages/pygarmin/link.py", line 264, in read_ack
    raise GarminError("Received neither ACK nor NAK packet")
          ^^^^^^^^^^^
NameError: name 'GarminError' is not defined

While it is still possible to understand, i think it is better to fix minor issue in exception. After applying patch:

Traceback (most recent call last):
  File "/home/nuclearcat/.local/bin/pygarmin", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/nuclearcat/.local/lib/python3.12/site-packages/pygarmin/pygarmin.py", line 1509, in main
    command(args)
  File "/home/nuclearcat/.local/lib/python3.12/site-packages/pygarmin/pygarmin.py", line 250, in info
    info += f"Unit ID: {self.gps.unit_id}\n"
                        ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/functools.py", line 995, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/nuclearcat/.local/lib/python3.12/site-packages/pygarmin/garmin.py", line 373, in unit_id
    self.link.send_packet(self.link.pid_command_data,
  File "/home/nuclearcat/.local/lib/python3.12/site-packages/pygarmin/protocol.py", line 27, in send_packet
    self.phys.send_packet(pid, data)
  File "/home/nuclearcat/.local/lib/python3.12/site-packages/pygarmin/link.py", line 235, in send_packet
    self.read_ack(pid)
  File "/home/nuclearcat/.local/lib/python3.12/site-packages/pygarmin/link.py", line 264, in read_ack
    raise mod_error.GarminError("Received neither ACK nor NAK packet")
pygarmin.error.GarminError: 'Received neither ACK nor NAK packet'